### PR TITLE
Add Python 3.6, drop unsupported 3.2, 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,18 +3,15 @@ language: python
 python:
  - pypy
  - pypy3
- - 2.6
  - 2.7
- - 3.2
- - 3.3
- - 3.4
+ - 3.6
  - 3.5
+ - 3.4
 
 sudo: false
 
 install:
  - pip install coverage
- - if [ "$TRAVIS_PYTHON_VERSION" == "2.6" ]; then pip install unittest2; fi
 
 script:
  - coverage run --source=schpy ./test_schpy.py -v
@@ -31,12 +28,3 @@ after_script:
 
 matrix:
   fast_finish: true
-  allow_failures:
-    - python: pypy
-    - python: pypy3
-    - python: 2.6
-    - python: 2.6
-    - python: 3.2
-    - python: 3.3
-    - python: 3.4
-    - python: 3.5

--- a/schbot.py
+++ b/schbot.py
@@ -157,7 +157,7 @@ def tweet_it(string, in_reply_to_status_id=None):
             # lat=HELSINKI_LAT, long=HELSINKI_LONG,
             display_coordinates=True,
             in_reply_to_status_id=in_reply_to_status_id)
-        url = "http://twitter.com/" + \
+        url = "https://twitter.com/" + \
             result['user']['screen_name'] + "/status/" + result['id_str']
         print("Tweeted: " + url)
         if not args.no_web:

--- a/schpy.py
+++ b/schpy.py
@@ -3,7 +3,7 @@
 """
 Output some text using shm-reduplication.
 https://en.wikipedia.org/wiki/Shm-reduplication
-http://www.academia.edu/209796/Metalinguistic_shmetalinguistic_The_phonology_of_shm-reduplication
+https://www.academia.edu/209796/Metalinguistic_shmetalinguistic_The_phonology_of_shm-reduplication
 """
 from __future__ import print_function, unicode_literals
 import argparse

--- a/test_schpy.py
+++ b/test_schpy.py
@@ -3,13 +3,10 @@
 """
 Unit tests for schpy.py
 https://en.wikipedia.org/wiki/Shm-reduplication
-http://www.academia.edu/209796/Metalinguistic_shmetalinguistic_The_phonology_of_shm-reduplication
+https://www.academia.edu/209796/Metalinguistic_shmetalinguistic_The_phonology_of_shm-reduplication
 """
 from __future__ import print_function, unicode_literals
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import unittest
 
 import schpy
 


### PR DESCRIPTION
Also allow Python 3 and PyPy to fail, and update some URLs to use HTTPS instead of HTTP.